### PR TITLE
Made footer always stick to bottom

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="section-sm">
+<footer class="section-sm fixed-bottom">
   <div class="container">
     <div class="row justify-content-center align-items-center">
       <div class="col-lg-5">


### PR DESCRIPTION
The footer is missing the bootstrap css class fixed-bottom which is making it not stick to the bottom of every page. For example, the search page when there are no results.