### PR TITLE
Made footer sticky and set the min screen height

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,13 +2,15 @@
 <html lang="{{ site.LanguageCode | default `en-US` }}">
 {{ partial "head.html" . }}
 
-<body>
+<body class="d-flex flex-column min-vh-100">
   {{ partialCached "preloader.html" . }}
   {{ partial "header.html" . }}
+  <main class="flex-fill">
   {{if and (not .IsHome) (ne .Section "blog") (ne .Permalink (`about/` | absURL)) (ne .Permalink (`search/` | absURL)) }}
   {{ partial "page-header.html" . }}
   {{end}}
   {{ block "main" . }}{{ end }}
+  </main>
   {{ partialCached "footer.html" . }}
   {{ partialCached "script.html" . }}
 </body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="section-sm fixed-bottom">
+<footer class="section-sm">
   <div class="container">
     <div class="row justify-content-center align-items-center">
       <div class="col-lg-5">


### PR DESCRIPTION
In my last PR, I mistakenly used the `.fixed-bottom` class that caused the footer to display over the site content. 

I have now used the recommended classes to set the structure of the site.

I have tested the output on different resolutions, and they look good.